### PR TITLE
Simple Shoob Vote

### DIFF
--- a/src/commands/Shoob/ShoobVote.js
+++ b/src/commands/Shoob/ShoobVote.js
@@ -1,0 +1,34 @@
+const { MessageEmbed } = require("discord.js");
+const Color = require("../../utils/Colors.json");
+const info = {
+  name: "shoobvote",
+  aliases: ["sv"],
+  matchCase: false,
+  category: "Shoob",
+  perms: ["ADD_REACTIONS", "MANAGE_MESSAGES", "READ_MESSAGE_HISTORY"],
+};
+// This is a workaround until we find a way to get vote timers
+module.exports = {
+  execute: async (instance, message) => {
+    if (!instance.shared["shoobv"]) instance.shared["shoobv"] = [];
+
+    instance.shared["shoobv"].push({
+      user: message.author.id,
+      last: Date.now(),
+    });
+
+    const embed = new MessageEmbed()
+      .setColor(Color.pink)
+      .setDescription(
+        `**Link to vote for Shoob:**\n**https://top.gg/bot/673362753489993749/vote**\n\nYou will be reminded in 12 hours. If you would not like to be notified, use **as!vote** instead!`
+      );
+    await message.channel.send({ embeds: [embed] });
+  },
+  info,
+  help: {
+    usage: "shoobvote",
+    examples: ["shoobvote"],
+    description:
+      "Information on voting for Shoob and get notified when vote timer is reset!",
+  },
+};

--- a/src/services/shoobvote.js
+++ b/src/services/shoobvote.js
@@ -1,0 +1,25 @@
+let interval = null;
+
+module.exports = {
+  start: async instance => {
+    if (interval !== null) return;
+    if (!instance.shared["shoobv"]) instance.shared["shoobv"] = [];
+
+    interval = setInterval(async () => {
+      for (const user of Object.keys(instance.shared["shoobv"])) {
+        const time = instance.shared["shoobv"][user];
+        if (Date.now() - time.last < 43500000) continue;
+        const userH = await instance.client.users.fetch(time.user);
+        if (!userH) continue;
+        await userH.send("You can now vote for shoob again!");
+        delete instance.shared["shoobv"][user];
+      }
+    }, 500000);
+  },
+  stop: async () => {
+    if (interval !== null) {
+      clearInterval(interval);
+      interval = null;
+    }
+  },
+};


### PR DESCRIPTION
Because we cannot track the timer for Shoob, this is a simple workaround to remind the user to vote for Shoob after 12 hours and 5 minutes (to ensure time to vote). s!shoobvote OR s!sv